### PR TITLE
Add insertRows() and initial test cases

### DIFF
--- a/__tests__/sheetquery.test.ts
+++ b/__tests__/sheetquery.test.ts
@@ -56,5 +56,30 @@ describe('SheetQuery', () => {
       expect(rows.every(row => row.Category === 'Shops')).toBeTruthy();
     });
   });
+
+  describe('insertRows', () => {
+    it('Should insert rows in the correct places matching column headings', () => {
+      const newRows = [
+        {
+          Amount: -554.23,
+          Name: 'BigBox, inc.'
+        },
+        {
+          Amount: -29.74,
+          Name: 'Fast-n-greasy Food, Inc.'
+        },
+      ];
+
+      // Insert rows
+      sheetQuery(ss)
+        .from(SHEET_NAME)
+        .insertRows(newRows);
+
+      const query = sheetQuery(ss).from(SHEET_NAME);
+      const rows = query.getRows();
+
+      expect(rows).toContain(newRows[0]);
+    });
+  });
 });
 

--- a/__tests__/sheetquery.test.ts
+++ b/__tests__/sheetquery.test.ts
@@ -62,11 +62,11 @@ describe('SheetQuery', () => {
       const newRows = [
         {
           Amount: -554.23,
-          Name: 'BigBox, inc.'
+          Name: 'BigBox, inc. __INSERT_TEST__'
         },
         {
           Amount: -29.74,
-          Name: 'Fast-n-greasy Food, Inc.'
+          Name: 'Fast-n-greasy Food, Inc. __INSERT_TEST__'
         },
       ];
 
@@ -78,7 +78,12 @@ describe('SheetQuery', () => {
       const query = sheetQuery(ss).from(SHEET_NAME);
       const rows = query.getRows();
 
-      expect(rows).toContain(newRows[0]);
+      const testRows = rows.filter(row => row.Name.includes('__INSERT_TEST__'));
+
+      expect(testRows[0].Name).toEqual(newRows[0].Name);
+      expect(testRows[0].Date).toEqual('');
+      expect(testRows[1].Name).toEqual(newRows[1].Name);
+      expect(testRows[1].Date).toEqual('');
     });
   });
 });

--- a/__tests__/sheetquery.test.ts
+++ b/__tests__/sheetquery.test.ts
@@ -1,0 +1,25 @@
+import { sheetQuery } from '../src/index';
+import { SpreadsheetApp } from 'gasmask';
+import { Spreadsheet, Sheet } from 'gasmask/dist/SpreadsheetApp';
+
+// @ts-ignore
+//global.SpreadsheetApp = SpreadsheetApp;
+
+let ss = new Spreadsheet();
+
+beforeAll(() => {
+  ss.insertSheet('TestSheet');
+});
+
+describe('SheetQuery', () => {
+  describe('getRows', () => {
+    it('should return rows for spreadsheet', () => {
+      const query = sheetQuery(ss)
+        .from('TestSheet');
+      const rows = query.getRows();
+
+      expect(rows).toEqual(null);
+    });
+  });
+});
+

--- a/__tests__/sheetquery.test.ts
+++ b/__tests__/sheetquery.test.ts
@@ -5,20 +5,55 @@ import { Spreadsheet, Sheet } from 'gasmask/dist/SpreadsheetApp';
 // @ts-ignore
 //global.SpreadsheetApp = SpreadsheetApp;
 
+const SHEET_NAME = 'TestSheet';
 let ss = new Spreadsheet();
 
-beforeAll(() => {
-  ss.insertSheet('TestSheet');
+let sheet = new Sheet(SHEET_NAME);
+const sheetData = [
+  ['Date', 'Amount', 'Name', 'Category'],
+  ['2021-01-01', 5.32, 'Kwickiemart', 'Shops'],
+  ['2021-01-02', 72.48, 'Shopmart', 'Shops'],
+  ['2021-01-03', 1.97, 'Kwickiemart', 'Shops'],
+  ['2021-01-03', 43.87, 'Gasmart', 'Gas'],
+  ['2021-01-04', 824.93, 'Wholepaycheck', 'Groceries'],
+];
+
+beforeEach(() => {
+  if (sheet) {
+    ss.deleteSheet(sheet);
+  }
+
+  ss.insertSheet(SHEET_NAME);
+
+  sheet = ss.getSheetByName(SHEET_NAME);
+  sheetData.forEach(row => sheet.appendRow(row));
 });
 
 describe('SheetQuery', () => {
   describe('getRows', () => {
-    it('should return rows for spreadsheet', () => {
+    it('should return all rows for spreadsheet', () => {
       const query = sheetQuery(ss)
-        .from('TestSheet');
+        .from(SHEET_NAME);
       const rows = query.getRows();
 
-      expect(rows).toEqual(null);
+      expect(rows.length).toBe(5);
+      expect(rows).toContainEqual({
+        "Amount": 72.48,
+        "Category": "Shops",
+        "Date": "2021-01-02",
+        "Name": "Shopmart",
+        "__meta": {"cols": 4, "row": 3},
+      });
+    });
+
+    it('should only return rows that match Category = Shops', () => {
+      const query = sheetQuery(ss)
+        .from(SHEET_NAME)
+        .where(row => row.Category === 'Shops');
+      const rows = query.getRows();
+
+      expect(rows.length).toBe(3);
+      expect(rows.every(row => row.Category === 'Shops')).toBeTruthy();
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,6 +1903,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "gasmask": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gasmask/-/gasmask-1.1.3.tgz",
+      "integrity": "sha512-Ev6MgU1K/jvMGQkDXwu0SgQPkHXnuRGLoNJz6FetEf0AbztFu2vDnrFiRhNenheNPr1YXZ6JpvkGXdm1chhpDw==",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/vlucas/sheetquery",
   "devDependencies": {
     "@types/jest": "^26.0.19",
+    "gasmask": "^1.1.3",
     "jest": "^26.6.3",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
+import type { Spreadsheet, Sheet } from 'gasmask/src/SpreadsheetApp';
+
 /**
  * Run new sheet query
+ *
+ * @param {Spreadsheet} activeSpreadsheet Specific spreadsheet to use, or will use SpreadsheetApp.getActiveSpreadsheet() if undefined\
+ * @return {SheetQuery}
  */
-export function sheetQuery(activeSpreadsheet: any) {
+export function sheetQuery(activeSpreadsheet?: any) {
   return new SheetQueryBuilder(activeSpreadsheet);
 }
 
@@ -25,7 +30,7 @@ export class SheetQueryBuilder {
   _sheetValues: any;
   _sheetHeadings: string[] | null = null;
 
-  constructor(activeSpreadsheet: any) {
+  constructor(activeSpreadsheet?: any) {
     this.activeSpreadsheet = activeSpreadsheet || SpreadsheetApp.getActiveSpreadsheet();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export class SheetQueryBuilder {
 
   _sheet: any;
   _sheetValues: any;
-  _sheetHeadings: string[] | null = null;
+  _sheetHeadings: string[] = [];
 
   constructor(activeSpreadsheet?: any) {
     this.activeSpreadsheet = activeSpreadsheet || SpreadsheetApp.getActiveSpreadsheet();
@@ -133,8 +133,8 @@ export class SheetQueryBuilder {
     return this.whereFn ? sheetValues.filter(this.whereFn) : sheetValues;
   }
 
-  getHeadings(): string[] | null {
-    if (!this._sheetHeadings) {
+  getHeadings(): string[] {
+    if (!this._sheetHeadings || !this._sheetHeadings.length) {
       const sheet = this.getSheet();
       const numCols = sheet.getLastColumn();
 
@@ -153,17 +153,17 @@ export class SheetQueryBuilder {
     const headings = this.getHeadings();
 
     newRows.forEach(row => {
+      const rowValues = headings.map(heading => {
+        return row[heading] ? row[heading] : '';
+      });
 
+      sheet.appendRow(rowValues);
     });
-
-    console.log({ headings });
-
-    // appendRow()
   }
 
   clearCache() {
     this._sheetValues = null;
-    this._sheetHeadings = null;
+    this._sheetHeadings = [];
 
     SpreadsheetApp.flush();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export function sheetQuery(activeSpreadsheet?: any) {
   return new SheetQueryBuilder(activeSpreadsheet);
 }
 
+export type DictObject = { [key: string]: any };
 export type RowObject = { [key: string]: any, __meta: { row: number, cols: number } };
 export type WhereFn = (row: RowObject) => boolean;
 export type UpdateFn = (row: RowObject) => RowObject | undefined;
@@ -106,15 +107,14 @@ export class SheetQueryBuilder {
       const rowValues = [];
       const sheetValues = sheet.getSheetValues(2, 1, sheet.getLastRow(), numCols);
       const numRows = sheetValues.length;
-
-      this._sheetHeadings = sheet.getSheetValues(1, 1, 1, numCols)[0];
+      const headings = this.getHeadings();
 
       for(let r = 0; r < numRows; r++) {
         const obj = { __meta: { row: r + 2, cols: numCols } }; // 2 = 0-based and heading row
 
         for(let c = 0; c < numCols; c++) {
           // @ts-expect-error: Headings are set already above, so possibility of an error here is nil
-          obj[this._sheetHeadings[c]] = sheetValues[r][c]; // @ts-ignore
+          obj[headings[c]] = sheetValues[r][c]; // @ts-ignore
         }
 
         rowValues.push(obj)
@@ -134,7 +134,31 @@ export class SheetQueryBuilder {
   }
 
   getHeadings(): string[] | null {
+    if (!this._sheetHeadings) {
+      const sheet = this.getSheet();
+      const numCols = sheet.getLastColumn();
+
+      this._sheetHeadings = sheet.getSheetValues(1, 1, 1, numCols)[0];
+    }
+
     return this._sheetHeadings;
+  }
+
+  /**
+   * Insert new rows into the spreadsheet
+   * Arrays of objects like { Heading: Value }
+   */
+  insertRows(newRows: DictObject[]) {
+    const sheet = this.getSheet();
+    const headings = this.getHeadings();
+
+    newRows.forEach(row => {
+
+    });
+
+    console.log({ headings });
+
+    // appendRow()
   }
 
   clearCache() {


### PR DESCRIPTION
SheetQuery now has an `insertRows` method that will append rows into a spreadsheet by column name. No more keeping track of column index positions!