### PR TITLE
patchRows() - Update index.js

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -191,6 +191,33 @@ class SheetQueryBuilder {
     this.clearCache();
     return this;
   }
+    patchRows(updateFn) {
+    const rows = this.getRows();
+    for (let i = 0; i < rows.length; i++) {
+      this.patchRow(rows[i], updateFn);
+    }
+    this.clearCache();
+    return this;
+  }
+  /**
+   * Patch single row
+   */
+  patchRow(row, updateFn) {
+    const rowMeta = row.__meta;
+    delete row.__meta;
+    const sourceRow = {...row}; // shallow copy
+    const updatedRow = updateFn(row) || row;    
+    const headings = this.getHeadings();
+    // Write those cells only where values were changed
+    headings.forEach((heading, col) => {
+      const newValue = updatedRow[heading];
+      if (newValue !== sourceRow[heading]){
+        const updateRowCell = this.getSheet().getRange(rowMeta.row, col + 1)
+        updateRowCell.setValues([[newValue]]);
+      }      
+    });
+    return this;
+  }
   /**
    * Update matched rows in spreadsheet with provided function
    *


### PR DESCRIPTION
Added patchRows and patchRow methods.
They are similar to updateRows/updateRow, but patchRow() only updates cells which was changed. So functions in some other cells will be safe. Only drawbacks are - 1) writing is cell by cell 2) making a shallow copy of every row to compare are there any changes.
Probably can be more optimized if somehow to read data from updateFn function. And take only fields to change directly. 
But proposed version can be added quite easily without major changes.
For now did only small testing, showing cell patch with formulas kept.
```const query = sheetQuery()
  .from('Transactions')
  .where((row) => row.Business.toLowerCase().includes('starbucks'))
  .patchRows((row) => {
    row.Category = 'Coffee Shops';
  });
  console.log(query.getRows()) ;
  ```